### PR TITLE
Proposed fix for error message in benchmark_resources.py

### DIFF
--- a/create_installer_state.py
+++ b/create_installer_state.py
@@ -77,6 +77,8 @@ def read_vesselinfo_from_file(filename):
       
     ValueError: Raised by rsa_string_to_publickey if the publickey string
       is improperly formated (IE not like "123 1234567").
+
+    IOError: Raised by open() if the vesselinfo file is missing.
       
   <Side Effects>
     None


### PR DESCRIPTION
Also amended a docstring in create_installer_state that an open()
call there could raise IOError if the requested file is not found.
See SeattleTestbed/resource#2 for details.
